### PR TITLE
Lazi socket connection

### DIFF
--- a/src/js/components/socket.component.js
+++ b/src/js/components/socket.component.js
@@ -26,10 +26,17 @@ export class SocketComponent extends HTMLElement {
 	}
 
 	onUrlChange (name, oldValue, newValue) {
-		this.ws.onopen = this.onOpenSocket.bind(this);
-		this.ws.onmessage = this.onMessageSocket.bind(this);
-		this.ws.onclose = this.onCloseSocket.bind(this);
+        this.url = newValue;
+        this.start();
 	}
+
+    start () {
+        if (!!this.url) {
+            this.ws.onopen = this.onOpenSocket.bind(this);
+            this.ws.onmessage = this.onMessageSocket.bind(this);
+            this.ws.onclose = this.onCloseSocket.bind(this);
+        }
+    }
 
 	onOpenSocket () {
 		let evt = new CustomEvent('open', {
@@ -60,7 +67,9 @@ export class SocketComponent extends HTMLElement {
 	}
 
 	receive (message) {
-		this.ws.send(JSON.stringify(message));
+        if (this.ws.readyState === this.ws.OPEN) {
+            this.ws.send(JSON.stringify(message));
+        }
 	}
 
 	/**
@@ -84,6 +93,14 @@ export class SocketComponent extends HTMLElement {
 	set isOpen (boolean) {
 		this._isOpen = !!boolean;
 	}
+
+    set url (url) {
+        this._url = url;
+    }
+
+    get url () {
+        return this._url;
+    }
 };
 
 customElements.define(SocketComponent.name, SocketComponent);

--- a/src/js/components/socket.component.js
+++ b/src/js/components/socket.component.js
@@ -36,10 +36,6 @@ export class SocketComponent extends HTMLElement {
     }
 
 	onOpenSocket () {
-		let evt = new CustomEvent('open', {
-			bubbles: true
-		});
-		this.dispatchEvent(evt);
 	}
 
 	onMessageSocket () {

--- a/src/js/components/socket.component.js
+++ b/src/js/components/socket.component.js
@@ -11,8 +11,6 @@ export class SocketComponent extends HTMLElement {
 
 	constructor () {
 		super();
-
-		this.isOpen = false;
 	}
 
 	attributeChangedCallback (name, oldValue, newValue) {
@@ -27,7 +25,6 @@ export class SocketComponent extends HTMLElement {
 
 	onUrlChange (name, oldValue, newValue) {
         this.url = newValue;
-        this.start();
 	}
 
     start () {
@@ -43,8 +40,6 @@ export class SocketComponent extends HTMLElement {
 			bubbles: true
 		});
 		this.dispatchEvent(evt);
-
-		this.isOpen = true;
 	}
 
 	onMessageSocket () {
@@ -62,12 +57,10 @@ export class SocketComponent extends HTMLElement {
 			bubbles: true
 		});
 		this.dispatchEvent(evt);
-
-		this.isOpen = false;
 	}
 
 	receive (message) {
-        if (this.ws.readyState === this.ws.OPEN) {
+        if (this.isOpen) {
             this.ws.send(JSON.stringify(message));
         }
 	}
@@ -82,16 +75,14 @@ export class SocketComponent extends HTMLElement {
 	get ws () {
 		if (!this._ws) {
 			this._ws = new WebSocket(this.dataset.url, this.dataset.protocol);
+
+            this.start();
 		}
 		return this._ws;
 	}
 
 	get isOpen () {
-		return this._isOpen;
-	}
-
-	set isOpen (boolean) {
-		this._isOpen = !!boolean;
+		return this.ws.readyState === this.ws.OPEN;
 	}
 
     set url (url) {

--- a/src/js/components/socket.component.js
+++ b/src/js/components/socket.component.js
@@ -11,6 +11,8 @@ export class SocketComponent extends HTMLElement {
 
 	constructor () {
 		super();
+
+        this.messageBuffer = [];
 	}
 
 	attributeChangedCallback (name, oldValue, newValue) {
@@ -36,6 +38,11 @@ export class SocketComponent extends HTMLElement {
     }
 
 	onOpenSocket () {
+        while (this.messageBuffer.length) {
+            let message = this.messageBuffer.pop();
+
+            this.receive(message);
+        }
 	}
 
 	onMessageSocket () {
@@ -58,6 +65,8 @@ export class SocketComponent extends HTMLElement {
 	receive (message) {
         if (this.isOpen) {
             this.ws.send(JSON.stringify(message));
+        } else {
+            this.messageBuffer.push(message);
         }
 	}
 


### PR DESCRIPTION
## Goals

Afin d'éviter de surcharger la communication `web socket`, l'initialisation de cette dernière est effectuée à la demande (`lazi`).

J'ai aussi fait un peu de refactor. Le `isOpen` est maintenant basé sur la lecture de l'état du `web socket` et non plus un booléen valorisé lors du callback d'initialisation.